### PR TITLE
Fix turtle import affecting unittests

### DIFF
--- a/src/turtle/runner/Logging.d
+++ b/src/turtle/runner/Logging.d
@@ -66,18 +66,22 @@ package void setupLogging ( )
     log = Log.lookup("turtle");
 }
 
-/*******************************************************************************
-
-    Backwards compatibility workaround for test suites that don't use turtle
-    runner and thus won't have `setupLogging` called normally.
-
-    See https://github.com/sociomantic/turtle/issues/166
-
-*******************************************************************************/
-
-static this ( )
+version (UnitTest) { }
+else
 {
-    setupLogging();
+    /***************************************************************************
+
+        Backwards compatibility workaround for test suites that don't use turtle
+        runner and thus won't have `setupLogging` called normally.
+
+        See https://github.com/sociomantic/turtle/issues/166
+
+    ***************************************************************************/
+
+    static this ( )
+    {
+        setupLogging();
+    }
 }
 
 /*******************************************************************************

--- a/src/turtle/runner/Logging.d
+++ b/src/turtle/runner/Logging.d
@@ -76,6 +76,8 @@ else
 
         See https://github.com/sociomantic/turtle/issues/166
 
+        Relying on this is deprecated, going to be removed in v9.0.0
+
     ***************************************************************************/
 
     static this ( )


### PR DESCRIPTION
Importing logging module cofigures global logger hierarchy which may
have undesired impact on completely unrelated unittests in applications
with makd 2.x because integration tests modules are compiled in as part
of regular unittest target.

FYI @leandro-lucarella-sociomantic 