### PR TITLE
Add missing `flush` call to --progress output

### DIFF
--- a/src/turtle/runner/actions/RunAll.d
+++ b/src/turtle/runner/actions/RunAll.d
@@ -134,7 +134,7 @@ public bool runAll ( ref Internal.RunnerConfig config, ref Context context,
                 {
                     last_progress_report = Clock.now.span.seconds;
                     Stdout.formatln("Running.. {} tests completed so far",
-                        progress);
+                        progress).flush();
                 }
             }
         }


### PR DESCRIPTION
If CI system uses buffer output, few lines from `--progress` mode won't be
printed in time otherwise.