### PR TITLE
Switch to standard tsunami Docker image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ workflows:
 templates:
     test: &test-template
         docker:
-        - image: mihailsstrasunssociomantic/dlang
+        - image: sociomantictsunami/dlang:xenial-v3
           user: cachalot
         steps:
         - checkout


### PR DESCRIPTION
v3.1 will include required cachalot user, using RC image to check that