### PR TITLE
Dump the daemon app outputs when it aborts

### DIFF
--- a/relnotes/output.feature.md
+++ b/relnotes/output.feature.md
@@ -1,0 +1,7 @@
+## Improve log output upon unexpected termination
+
+Now instead of just printing `Early termination from 'app', aborting`, turtle
+will also log last stderr/stdout lines from the tested application, even if
+normally logging if tested application output is disabled.
+
+Turtle will also mention spawned process command-line arguments if any.

--- a/src/turtle/application/TestedDaemonApplication.d
+++ b/src/turtle/application/TestedDaemonApplication.d
@@ -18,6 +18,8 @@ import ocean.task.util.Timer;
 import ocean.task.Scheduler;
 import ocean.io.select.client.TimerEvent;
 import ocean.text.convert.Formatter;
+import ocean.text.Util;
+import ocean.util.log.Logger;
 
 import turtle.runner.Logging;
 import turtle.application.model.TestedApplicationBase;
@@ -62,8 +64,22 @@ class TestedDaemonApplication : TestedApplicationBase
         {
             if ( !this.outer.expecting_termination )
             {
-                .log.error("Early termination from '{}', aborting",
-                    this.process.programName());
+                .log.error(
+                    "Early termination from '{}', aborting.",
+                    join(this.process.args, " ")
+                );
+
+                if (Log.root.level < Level.Trace)
+                {
+                    .log.error("Last console output:");
+
+                    foreach (line; this.last_output[])
+                    {
+                        if (line.length)
+                            .log.error(line);
+                    }
+                }
+
                 abort();
             }
         }

--- a/src/turtle/application/model/ExternalProcess.d
+++ b/src/turtle/application/model/ExternalProcess.d
@@ -74,6 +74,14 @@ class ExternalProcess : EpollProcess
 
     /***************************************************************************
 
+        Stores last output lines from the external process
+
+    ***************************************************************************/
+
+    protected cstring[100] last_output;
+
+    /***************************************************************************
+
         Constructor
 
         Params:
@@ -129,7 +137,10 @@ class ExternalProcess : EpollProcess
         foreach (line; splitLines(cast(mstring) data))
         {
             if (line.length)
+            {
+                this.rotateOutputLines(line);
                 this.process_log.trace(line);
+            }
         }
     }
 
@@ -147,7 +158,10 @@ class ExternalProcess : EpollProcess
         foreach (line; splitLines(cast(mstring) data))
         {
             if (line.length)
+            {
+                this.rotateOutputLines(line);
                 this.process_log.error(line);
+            }
         }
     }
 
@@ -278,4 +292,17 @@ class ExternalProcess : EpollProcess
         }
     }
 
+    /***************************************************************************
+
+        Appends to the front of `this.last_output` buffer, shifting existing
+        elements towards its end (but never resizing).
+
+    ***************************************************************************/
+
+    private void rotateOutputLines ( cstring line )
+    {
+        for (ptrdiff_t i = this.last_output.length-1; i > 0; --i)
+            this.last_output[i-1] = this.last_output[i];
+        this.last_output[$-1] = line;
+    }
 }


### PR DESCRIPTION
This should make debugging a certain class of problem (e.g. stomping prevention being triggered) much easier.

Part of (or maybe even fixes) https://github.com/sociomantic-tsunami/turtle/issues/11