### PR TITLE
Fix regression in manual sandbox path placement

### DIFF
--- a/src/turtle/runner/Runner.d
+++ b/src/turtle/runner/Runner.d
@@ -762,6 +762,7 @@ class TurtleRunner ( TaskT ) : CliApp
             // Remove when removing deprecated Runner constructor
             if (this.task.config.name.length > 0)
             {
+                path = this.task.context.paths.tmp_dir;
                 this.task.context.paths.sandbox = path
                     ~ "/sandbox-" ~ this.task.config.name ~ "/";
             }


### PR DESCRIPTION
Fixes #33

During implementing new sandbox naming system in 8.3.0, old deprecated
functionality was accidentally changed to use project path as root, not
tmp folder path.