### PR TITLE
Workaround ocean 3.6.0 breaking change

### DIFF
--- a/src/turtle/runner/Runner.d
+++ b/src/turtle/runner/Runner.d
@@ -614,6 +614,10 @@ class TurtleRunner ( TaskT ) : CliApp
     {
         SchedulerConfiguration config;
         initScheduler(config);
+        // clear exception handler to workaround regression caused by ocean
+        // v3.6.0 and later which causes test suite to abort during termination
+        // of the tested app because of unhandled exception:
+        theScheduler.exception_handler = null;
         theScheduler.schedule(this.task);
         theScheduler.eventLoop();
         return this.task.ok ? 0 : -1;


### PR DESCRIPTION
In 3.6.0 ocean started to define custom scheduler exception handler in
-version=UnitTest to abort tests early and help in debugging problems.
This has caused an unintended regression in turtle when it is compiled
with makd 1.x.x (because it was using -version=UnitTest flag), causing
aborts on few exceptions that are expected to happen in the epoll
context.