### PR TITLE
Print current sandbox path on test failure

### DIFF
--- a/src/turtle/runner/internal/DefaultTestRunner.d
+++ b/src/turtle/runner/internal/DefaultTestRunner.d
@@ -180,6 +180,7 @@ public final class DefaultTestRunner
             .log.error("FAIL at {}:{}", e.file, e.line);
             increaseLogIndent();
             .log.error("({})", getMsg(e));
+            .log.error("Sandbox path was '{}'", context.paths.sandbox);
             decreaseLogIndent();
 
             if (desc.fatal)


### PR DESCRIPTION
Fixes #37

Makes debugging problems easier when tests run in non-verbose mode and
fail.