### PR TITLE
Always show the last console output before abort

### DIFF
--- a/src/turtle/application/TestedDaemonApplication.d
+++ b/src/turtle/application/TestedDaemonApplication.d
@@ -69,15 +69,12 @@ class TestedDaemonApplication : TestedApplicationBase
                     join(this.process.args, " ")
                 );
 
-                if (Log.root.level < Level.Trace)
-                {
-                    .log.error("Last console output:");
+                .log.error("Last console output:");
 
-                    foreach (line; this.last_output[])
-                    {
-                        if (line.length)
-                            .log.error(line);
-                    }
+                foreach (line; this.last_output[])
+                {
+                    if (line.length)
+                        .log.error(line);
                 }
 
                 abort();


### PR DESCRIPTION
If we're going to abort anyway, why not just always show the last console output.