### PR TITLE
Fix unix socket path length issue

### DIFF
--- a/src/turtle/runner/Runner.d
+++ b/src/turtle/runner/Runner.d
@@ -508,7 +508,7 @@ class TurtleRunnerTask ( TestedAppKind Kind ) : TaskWith!(ExceptionForwarding)
 
         // try connecting to unix socket at path `pwd`/turtle.socket in case
         // it was created by tested app
-        auto socket_path = Environment.toAbsolute("turtle.socket".dup);
+        auto socket_path = "turtle.socket";
         if (FilePath(socket_path).exists())
         {
             .log.trace("Found {}, connecting", socket_path);


### PR DESCRIPTION
Turtle was trying to use absolute path for its unix socket and it hits
UNIX_PATH_MAX limit very quickly. There is no reason why absolute path
had to be used here.