### PR TITLE
Remove usage of ocean's Const/Immut qualifiers

### DIFF
--- a/src/turtle/application/TestedCliApplication.d
+++ b/src/turtle/application/TestedCliApplication.d
@@ -42,7 +42,7 @@ class TestedCliApplication : TestedApplicationBase
     private final class ExternalCliProcess : ExternalProcess
     {
         private this ( cstring cmd,
-            cstring work_dir, Const!(cstring)[] arguments = null,
+            cstring work_dir, const(cstring)[] arguments = null,
             istring[istring] env = null )
         {
             super(cmd, work_dir, arguments, env);
@@ -138,7 +138,7 @@ class TestedCliApplication : TestedApplicationBase
     ***************************************************************************/
 
     public this ( cstring executable_name, double timeout,
-        cstring sandbox, Const!(cstring)[] args = null, istring[istring] env = null )
+        cstring sandbox, const(cstring)[] args = null, istring[istring] env = null )
     {
         super(executable_name, sandbox);
         this.process = new ExternalCliProcess(this.executable_path, sandbox,
@@ -169,7 +169,7 @@ class TestedCliApplication : TestedApplicationBase
 
     ***************************************************************************/
 
-    override public void start ( Const!(cstring)[] args = null )
+    override public void start ( const(cstring)[] args = null )
     {
         this.stdout_buffer.length = 0;
         this.stderr_buffer.length = 0;

--- a/src/turtle/application/TestedDaemonApplication.d
+++ b/src/turtle/application/TestedDaemonApplication.d
@@ -55,7 +55,7 @@ class TestedDaemonApplication : TestedApplicationBase
     private final class ExternalDaemonProcess : ExternalProcess
     {
         private this ( cstring cmd, cstring work_dir,
-            Const!(cstring)[] arguments = null, istring[istring] env = null )
+            const(cstring)[] arguments = null, istring[istring] env = null )
         {
             super(cmd, work_dir, arguments, env);
         }
@@ -119,7 +119,7 @@ class TestedDaemonApplication : TestedApplicationBase
     ***************************************************************************/
 
     public this ( cstring executable_name, double delay,
-        cstring sandbox, Const!(cstring)[] args = null, istring[istring] env = null )
+        cstring sandbox, const(cstring)[] args = null, istring[istring] env = null )
     {
         super(executable_name, sandbox);
         this.process = new ExternalDaemonProcess(this.executable_path, sandbox,
@@ -138,7 +138,7 @@ class TestedDaemonApplication : TestedApplicationBase
 
     ***************************************************************************/
 
-    override public void start ( Const!(cstring)[] args = null )
+    override public void start ( const(cstring)[] args = null )
     {
         this.expecting_termination = false;
         super.start(args);

--- a/src/turtle/application/model/ExternalProcess.d
+++ b/src/turtle/application/model/ExternalProcess.d
@@ -69,7 +69,7 @@ class ExternalProcess : EpollProcess
 
     ***************************************************************************/
 
-    private Const!(cstring)[] arguments;
+    private const(cstring)[] arguments;
 
     /***************************************************************************
 
@@ -94,7 +94,7 @@ class ExternalProcess : EpollProcess
     ***************************************************************************/
 
     public this ( cstring cmd, cstring work_dir,
-        Const!(cstring)[] arguments = null, istring[istring] env = null )
+        const(cstring)[] arguments = null, istring[istring] env = null )
     {
         this.errno_e = new ErrnoException;
         this.command = cmd;
@@ -175,7 +175,7 @@ class ExternalProcess : EpollProcess
 
     ***********************************************************************/
 
-    public override void start ( Const!(mstring)[] extra_args = null )
+    public override void start ( const(cstring)[] extra_args = null )
     {
         this.startImpl(extra_args);
     }
@@ -237,7 +237,7 @@ class ExternalProcess : EpollProcess
 
     ***************************************************************************/
 
-    protected void startImpl ( Const!(mstring)[] extra_args )
+    protected void startImpl ( const(cstring)[] extra_args )
     {
         this.process.setWorkDir(this.work_dir.dup);
         super.start(command ~ this.arguments ~ extra_args);

--- a/src/turtle/application/model/TestedApplicationBase.d
+++ b/src/turtle/application/model/TestedApplicationBase.d
@@ -127,7 +127,7 @@ abstract class TestedApplicationBase
 
     ***************************************************************************/
 
-    public abstract void start ( Const!(cstring)[] args = null )
+    public abstract void start ( const(cstring)[] args = null )
     {
         // disable previous kill timer if present
         this.kill_timer.reset();


### PR DESCRIPTION
Those cannot be deprecated by Ocean, since they are templates,
and the compiler doesn't correctly show deprecations for templates,
but we can remove them here so the next major is free to kill them.