### PR TITLE
Simplify test matrix, on test 2.09{2,3}

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ env:
     global:
         # Make sure beaver is in the PATH
         - PATH="$(git config -f .gitmodules submodule.beaver.path)/bin:$PATH"
-        - DIST=xenial
-        - COV=1
+        - DIST=bionic
+        - COV=0
 
 # Basic config is inherited from the global scope
 jobs:
@@ -32,17 +32,9 @@ jobs:
     include:
         # Test matrix
         - <<: *test-matrix
-          env: DMD=2.078.3.s* F=devel
+          env: DMD=2.092.* F=devel
         - <<: *test-matrix
-          env: DMD=2.085.* F=devel
-        - <<: *test-matrix
-          env: DIST=bionic DMD=2.078.* F=devel
-        - <<: *test-matrix
-          env: DIST=bionic DMD=2.085.* F=devel
-        - <<: *test-matrix
-          env: DIST=bionic DMD=2.091.* F=devel
-        - <<: *test-matrix
-          env: DIST=bionic DMD=2.093.* F=devel
+          env: DMD=2.093.* F=devel COV=1
 
         # Additional stages
         - stage: Closure allocation check


### PR DESCRIPTION
Now that other projects dropped v2.091.0 and lower, we can too.
Additionally, we only test devel because Turtle is a test framework.