### PR TITLE
Logging: Use FormatterSink alias instead of delegate type

### DIFF
--- a/src/turtle/runner/Logging.d
+++ b/src/turtle/runner/Logging.d
@@ -83,7 +83,7 @@ private class SimpleLayout : Appender.Layout
         assert (SimpleLayout.indent_count >= 0);
     }
 
-    override void format (LogEvent event, scope void delegate(cstring) dg)
+    override void format (LogEvent event, scope FormatterSink dg)
     {
         static mstring buffer;
         sformat(buffer, "[{0,-10}] ", event.name);


### PR DESCRIPTION
This ensures that whatever the underlying sink is, the override is correct.